### PR TITLE
Add daily and hourly consumptions

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,6 +2,6 @@
 Import class from file
 """
 
-from daikinapi.daikinapi import Daikin
+from daikinapi.daikinapi import Daikin, Schedule
 
-__all__ = ["Daikin"]
+__all__ = ["Daikin", "Schedule"]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ daikinapi python module manifest
 from os.path import abspath, dirname, join
 from setuptools import setup
 
-__version__ = "1.0.5"
+__version__ = "1.0.6"
 
 
 def read_file(filename):


### PR DESCRIPTION
Hello,

I propose you this contribution to add the hourly/daily power consumption. I found that there are more options to the API, but with this changes it is at least possible to display/graph a total consumption for the current day (hour by hour) and each of the previous days of the past week (day by day), and for instance to compare today vs yesterday, or display an overall consumption on the past 7 days etc.

Cheers.